### PR TITLE
Fix: Correct AndroidManifest.xml for Android 12+ compatibility

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,15 +9,19 @@
 
     <!-- Classic discovery / admin (Pre-Android 12) -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30"
+        tools:ignore="ProtectedPermissions" />
     
     <!-- Android 12+ runtime-permission split -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     
     <!-- Pre-Android 12 discovery needs location permissions -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:ignore="CoarseFineLocation" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     
     <!-- Storage Permissions -->


### PR DESCRIPTION
### **User description**
This commit fixes several issues in the `AndroidManifest.xml` file that could cause errors or warnings in Android Studio, particularly for apps targeting Android 12 (API 31) and higher.

The changes are:

- **Added `usesPermissionFlags`:** The `BLUETOOTH_SCAN` permission now includes the `android:usesPermissionFlags="neverForLocation"` attribute. This is a requirement for apps that use Bluetooth scanning for non-location purposes on Android 12+.
- **Suppressed Warnings:** Added `tools:ignore` attributes to the `ACCESS_FINE_LOCATION` and `BLUETOOTH_ADMIN` permissions to suppress common lint warnings in Android Studio.


___

### **PR Type**
Bug fix


___

### **Description**
- Added Android 12+ Bluetooth permission compatibility flags

- Suppressed lint warnings for protected permissions

- Enhanced AndroidManifest.xml for modern Android versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AndroidManifest.xml"] --> B["BLUETOOTH_SCAN permission"]
  A --> C["BLUETOOTH_ADMIN permission"]
  A --> D["ACCESS_FINE_LOCATION permission"]
  B --> E["Added neverForLocation flag"]
  C --> F["Added ProtectedPermissions ignore"]
  D --> G["Added CoarseFineLocation ignore"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AndroidManifest.xml</strong><dd><code>Android 12+ Bluetooth permission compatibility fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/app/src/main/AndroidManifest.xml

<ul><li>Added <code>usesPermissionFlags="neverForLocation"</code> to <code>BLUETOOTH_SCAN</code> <br>permission<br> <li> Added <code>tools:ignore="ProtectedPermissions"</code> to <code>BLUETOOTH_ADMIN</code> <br>permission<br> <li> Added <code>tools:ignore="CoarseFineLocation"</code> to <code>ACCESS_FINE_LOCATION</code> <br>permission<br> <li> Improved formatting with multi-line permission declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/darkorad/lion-diag-307-scan/pull/32/files#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1d">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

